### PR TITLE
chore: update Node.js version requirement and dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.1.1 - 2025-09-07
+
+- chore: update Node.js version requirement and dependencies
+
 ## 0.1.0 - 2025-09-07
 
 - Project start.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Tiny, opinionated HTTP tunnel for local development, built on Cloudflare Workers + Durable Objects. The CLI opens a WebSocket to your Worker and proxies public HTTP traffic from a slug subdomain like `https://<slug>.<your-domain>` to your local server (for example, `http://localhost:8080`).
 
 - Worker uses a custom domain with wildcard subdomains (e.g. `*.example.com`) and routes traffic to a Durable Object that multiplexes requests over a single WS connection to your machine.
-- CLI is a single-file Node.js 18+ binary published to npm and runnable via npx.
+- CLI is a single-file Node.js 22+ binary published to npm and runnable via npx.
 - Safe defaults: strips service Authorization from proxied requests, sets X-Forwarded-* headers, basic concurrency limiting per isolate, and throttle windows for repeated unauthenticated hits.
 
 ## How it works (high level)
@@ -18,7 +18,7 @@ Tiny, opinionated HTTP tunnel for local development, built on Cloudflare Workers
 
 ## Requirements
 
-- Node.js 18 or newer on the client side (for the CLI).
+- Node.js 22 or newer on the client side (for the CLI).
 - A Cloudflare account with a zone using your custom domain (DNS managed by Cloudflare) to attach Worker routes.
 - You must own a domain whose DNS is managed by Cloudflare (active zone). Wildcard subdomains are supported by free plan.
 - Wrangler CLI installed and authenticated: <https://developers.cloudflare.com/workers/wrangler/>
@@ -131,7 +131,7 @@ Usage: npx httpsier --http http://localhost:8080 --api [token] --worker https://
 - Cloudflare Workers Runtime and Cache API (throttle windows).
 - Cloudflare Durable Objects (session registry, sticky WS per slug).
 - Wrangler (build/deploy/secrets).
-- Node.js 18+ (global fetch, WHATWG streams in the CLI).
+- Node.js 22+ (global fetch, WHATWG streams in the CLI).
 - WebSocket (ws) for the tunnel.
 - TypeScript + esbuild for a single-file ESM CLI bundle.
 - ESLint + Prettier for linting/formatting.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "httpsier",
-	"version": "0.1.0",
+	"version": "0.1.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "httpsier",
-			"version": "0.1.0",
+			"version": "0.1.1",
 			"license": "MIT",
 			"dependencies": {
 				"tslib": "^2.6.2",
@@ -17,7 +17,7 @@
 			},
 			"devDependencies": {
 				"@eslint/js": "^9.34.0",
-				"@types/node": "^20.0.0",
+				"@types/node": "22.18.1",
 				"@types/ws": "^8.5.10",
 				"@typescript-eslint/eslint-plugin": "^8.42.0",
 				"@typescript-eslint/parser": "^8.42.0",
@@ -30,7 +30,7 @@
 				"typescript": "^5.5.0"
 			},
 			"engines": {
-				"node": ">=18"
+				"node": ">=22"
 			}
 		},
 		"node_modules/@esbuild/aix-ppc64": {
@@ -779,9 +779,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@types/node": {
-			"version": "20.19.13",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.13.tgz",
-			"integrity": "sha512-yCAeZl7a0DxgNVteXFHt9+uyFbqXGy/ShC4BlcHkoE0AfGXYv/BUiplV72DjMYXHDBXFjhvr6DD1NiRVfB4j8g==",
+			"version": "22.18.1",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-22.18.1.tgz",
+			"integrity": "sha512-rzSDyhn4cYznVG+PCzGe1lwuMYJrcBS1fc3JqSa2PvtABwWo+dZ1ij5OVok3tqfpEBCBoaR4d7upFJk73HRJDw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "httpsier",
-	"version": "0.1.0",
+	"version": "0.1.1",
 	"description": "Tiny HTTP tunnel for local development using Cloudflare Workers. Proxies public traffic from a subdomain to your local server via WebSocket.",
 	"type": "module",
 	"main": "dist/index.js",
@@ -9,7 +9,7 @@
 		"httpsier": "dist/index.js"
 	},
 	"engines": {
-		"node": ">=18"
+		"node": ">=22"
 	},
 	"scripts": {
 		"build": "esbuild src/index.ts --bundle --platform=node --format=esm --external:ws --outfile=dist/index.js --banner:js='#!/usr/bin/env node' && npm run build:types",
@@ -42,7 +42,7 @@
 	],
 	"devDependencies": {
 		"@eslint/js": "^9.34.0",
-		"@types/node": "^20.0.0",
+		"@types/node": "22.18.1",
 		"@types/ws": "^8.5.10",
 		"@typescript-eslint/eslint-plugin": "^8.42.0",
 		"@typescript-eslint/parser": "^8.42.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -438,18 +438,7 @@ export function main(input: CliOptions): number {
 	return 0;
 }
 
-// Direct execution support when bundled to dist/index.js
-const isDirectRun = (() => {
-	try {
-		const thisFile = new URL("", import.meta.url).href;
-		const entry = `file://${process.argv[1]}`;
-		return thisFile === entry || process.argv[1]?.endsWith("index.js");
-	} catch {
-		return false;
-	}
-})();
-
-if (isDirectRun) {
+if (import.meta.main) {
 	main({ argv: process.argv.slice(2) });
 }
 


### PR DESCRIPTION
- Bump Node.js version requirement from 18 to 22 in package.json and package-lock.json
- Update @types/node dependency to version 22.18.1
- Modify README to reflect the new Node.js version requirement
- Adjust changelog for version 0.1.1
- Refactor direct execution check in index.ts to use import.meta.main